### PR TITLE
Use a different link indicator

### DIFF
--- a/gptar.opam
+++ b/gptar.opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml"
   "dune" {>= "3.7"}
   "gpt"
-  "tar"
+  "tar" {>= "3.0.0"}
   "checkseum"
   "odoc" {with-doc}
 ]

--- a/lib/Gptar.ml
+++ b/lib/Gptar.ml
@@ -1,7 +1,9 @@
 let gpt_sizeof = 92 (* Gpt.sizeof *)
 let tar_chksum_offset = 148
 let tar_link_indicator_offset = 156
-let gptar_link_indicator = 'G'
+(* 'V' is for volume headers which GNU tar will silently skip when extracting
+   according to https://uni.horse/executable-tarballs.html*)
+let gptar_link_indicator = 'V'
 
 let marshal_protective_mbrtar buf t =
   (* We need to write 0x55, 0xAA at offsets 510-511.


### PR DESCRIPTION
This [fine article][executable-tarballs] about how to create a tar archive that is also an executable mentions that the `'V'` link indicator, a volume header, results in the content being skipped in GNU tar. This is desirable for us for the GPT header.

[executable-tarballs]: https://uni.horse/executable-tarballs.html